### PR TITLE
[policy] Removing data envelope to match implementation.

### DIFF
--- a/policy/README.md
+++ b/policy/README.md
@@ -130,16 +130,14 @@ The `updated` field in the payload wrapper should be set to the time of publishi
     "version": "0.4.0",
     "updated": "1570035222868",
     "end_date": "1570035222868",
-    "data": {
-        "policies": [
-            {
-                // policy JSON 1
-            },
-            {
-                // policy JSON 2
-            }
-        ]
-    }
+    "policies": [
+        {
+            // policy JSON 1
+        },
+        {
+            // policy JSON 2
+        }
+    ]
 }
 ```
 
@@ -151,16 +149,14 @@ The optional `end_date` field applies to all policies represented in the file.
 {
     "version": "0.4.0",
     "updated": "1570035222868",
-    "data": {
-        "geographies": [
-            {
-                // GeoJSON Feature 1
-            },
-            {
-                // GeoJSON Feature 2
-            }
-        ]
-    }
+    "geographies": [
+        {
+            // GeoJSON Feature 1
+        },
+        {
+            // GeoJSON Feature 2
+        }
+    ]
 }
 ```
 
@@ -170,15 +166,13 @@ The optional `end_date` field applies to all policies represented in the file.
 
 All response fields must use `lower_case_with_underscores`.
 
-Response bodies must be a `UTF-8` encoded JSON object and must minimally include the MDS `version`, a timestamp indicating the last time the data was `updated`, and a `data` payload:
+Response bodies must be a `UTF-8` encoded JSON object and must minimally include the MDS `version`, a timestamp indicating the last time the data was `updated`:
 
 ```json
 {
     "version": "x.y.z",
     "updated": "1570035222868",
-    "data": {
-        // endpoint/file specific payload
-    }
+    // endpoint/file specific payload
 }
 ```
 


### PR DESCRIPTION
### Explain pull request

Please provide a clear and concise reason for this pull request and the impact of the change

### Is this a breaking change

A breaking change would require consumers or implementors of the API to modify their code for it to continue to function (ex: renaming of a required field or the change in data type of an existing field). A non-breaking change would allow existing code to continue to function (ex: addition of an optional field or the creation of a new optional endpoint). 

 * Yes, breaking
 * No, not breaking
 * I'm not sure

### Impacted Spec

Which spec(s) will this pull request impact?

 * `agency`
 * `policy`
 * `provider`

### Additional context

Add any other context or screenshots about the feature request here.
