### PR TITLE
Additional cleanups for Reconciliation

### DIFF
--- a/agency/README.md
+++ b/agency/README.md
@@ -50,10 +50,10 @@ Path Params:
 
 If `device_id` is specified, `GET` will return a single vehicle record, otherwise it will be a list of vehicle records with pagination details per the [JSON API](https://jsonapi.org/format/#fetching-pagination) spec:
 
-```
+```json
 {
-	"vehicles": [ ... ]
- 	"links": {
+    "vehicles": [ ... ]
+    "links": {
         "first": "https://...",
         "last": "https://...",
         "prev": "https://...",

--- a/agency/README.md
+++ b/agency/README.md
@@ -23,15 +23,11 @@ This specification uses data types including timestamps, UUIDs, and vehicle stat
 
 `agency` APIs must handle requests for specific versions of the specification from clients.
 
-Versioning must be implemented as specified in the [`General information versioning section`][versioning].
+Versioning must be implemented as specified in the [Versioning section][versioning].
 
-### Responses
+### Responses and Error Messages
 
-See [responses][responses]
-
-### Error Message Format
-
-See [error message format][error-message-format]
+See the [Responses][responses] and [Error Messages][error-messages] sections.
 
 ### Authorization
 
@@ -240,9 +236,9 @@ A standard point of vehicle telemetry. References to latitude and longitude impl
 [general]: /general-information.md
 [versioning]: /general-information.md#versioning
 [responses]: /general-information.md#responses
-[error-message-format]: /general-information.md#error-message-format
+[error-messages]: /general-information.md#error-messages
 [vehicle-types]: /general-information.md#vehicle-types
 [vehicle-states]: /general-information.md#vehicle-states
-[vehicle-events]: /general-information.md#vehicle-events
+[vehicle-events]: /general-information.md#vehicle-state-events
 [propulsion-types]: /general-information.md#propulsion-types
 [hdop]: https://support.esri.com/en/other-resources/gis-dictionary/term/358112bd-b61c-4081-9679-4fca9e3eb926

--- a/general-information.md
+++ b/general-information.md
@@ -161,11 +161,11 @@ Note that to handle out-of-order events, the validity of the prior-state shall n
 | any | `unknown`     | `missing`            | The vehicle is not at its last reported GPS location, or that location is wildly in error |
 | any | `unknown`     | `out_of_comms`       | The vehicle is unable to transmit its GPS location |
 
-NOTES: 
+NOTES:
 
 Should we try to handle "unlicensed movements"?
 
-What's the best way to return from `unknown`? 
+What's the best way to return from `unknown`?
 
 [Top][toc]
 
@@ -197,9 +197,10 @@ Accept: application/vnd.mds+json;version=0.3
 ```
 
 > Since versioning was not available from the start, the following APIs provide a fallback version if the `Accept` header is not set as specified above:
-> - The `provider` API must respond as if version `0.2` was requested.
-> - The `agency` API must respond as if version `0.3` was requested.
-> - The `policy` API must respond as if version `0.4` was requested.
+>
+> * The `provider` API must respond as if version `0.2` was requested.
+> * The `agency` API must respond as if version `0.3` was requested.
+> * The `policy` API must respond as if version `0.4` was requested.
 
 If an unsupported or invalid version is requested, the API must respond with a status of `406 Not Acceptable`. If this occurs, a client can explicitly negotiate available versions.
 

--- a/general-information.md
+++ b/general-information.md
@@ -1,6 +1,6 @@
 # Mobility Data Specification: **General information**
 
-This document contains specifications that are shared between the various MDS APIs such as `agency`, `provider` and `policy`.
+This document contains specifications that are shared between the various MDS APIs such as [`agency`][agency], [`policy`][policy], and [`provider`][provider].
 
 ## Table of Contents
 
@@ -221,4 +221,7 @@ The client can use the returned value verbatim as a version request in the `Acce
 
 [Top][toc]
 
+[agency]: /agency/README.md
+[policy]: /policy/README.md
+[provider]: /provider/README.md
 [toc]: #table-of-contents

--- a/general-information.md
+++ b/general-information.md
@@ -4,74 +4,19 @@ This document contains specifications that are shared between the various MDS AP
 
 ## Table of Contents
 
-* [Versioning](#versioning)
 * [Beta Features](#beta-features)
-* [Responses](#responses)
-* [Error Message Format](#error-message-format)
-* [Timestamps](#timestamps)
-* [Strings](#strings)
-* [UUIDs](#uuids)
 * [Costs and Currencies](#costs-and-currencies)
 * [Devices](#devices)
-* [Vehicle Types](#vehicle-types)
 * [Propulsion Types](#propulsion-types)
+* [Responses](#responses)
+  * [Error Messages](#error-messages)
+* [Strings](#strings)
+* [Timestamps](#timestamps)
+* [UUIDs](#uuids)
 * [Vehicle States](#vehicle-states)
-* [Vehicle Events](#vehicle-events)
-
-## Versioning
-
-MDS APIs must handle requests for specific versions of the specification from clients.
-
-Versioning must be implemented through the use of a custom media-type, `application/vnd.mds+json`, combined with a required `version` parameter.
-
-The version parameter specifies the dot-separated combination of major and minor versions from a published version of the specification. For example, the media-type for version `1.0.1` would be specified as `application/vnd.mds+json;version=1.0`
-
-Clients must specify the version they are targeting through the `Accept` header. For example:
-
-```http
-Accept: application/vnd.mds+json;version=0.3
-```
-
-> Since versioning was not available from the start, the following APIs provide a fallback version if the `Accept` header is not set as specified above:
-> - The `provider` API must respond as if version `0.2` was requested.
-> - The `agency` API must respond as if version `0.3` was requested.
-> - The `policy` API must respond as if version `0.4` was requested.
-
-If an unsupported or invalid version is requested, the API must respond with a status of `406 Not Acceptable`. If this occurs, a client can explicitly negotiate available versions.
-
-A client negotiates available versions using the `OPTIONS` method to an MDS endpoint. For example, to check if `trips` supports either version `0.2` or `0.3` with a preference for `0.2`, the client would issue the following request:
-
-```http
-OPTIONS /trips/ HTTP/1.1
-Host: provider.example.com
-Accept: application/vnd.mds+json;version=0.2,application/vnd.mds+json;version=0.3;q=0.9
-```
-
-The response will include the most preferred supported version in the `Content-Type` header. For example, if only `0.3` is supported:
-
-```http
-Content-Type: application/vnd.mds+json;version=0.3
-```
-
-The client can use the returned value verbatim as a version request in the `Accept` header.
-
-## Responses
-
-* **200:** OK: operation successful.
-* **201:** Created: `POST` operations, new object created
-* **400:** Bad request.
-* **401:** Unauthorized: Invalid, expired, or insufficient scope of token.
-* **404:** Not Found: Object does not exist, returned on `GET` or `POST` operations if the object does not exist.
-* **409:** Conflict: `POST` operations when an object already exists and an update is not possible.
-* **500:** Internal server error: In this case, the answer may contain a `text/plain` body with an error message for troubleshooting.
-
-## Error Message Format
-
-| Field               | Type     | Field Description      |
-| ------------------- | -------- | ---------------------- |
-| `error`             | String   | Error message string   |
-| `error_description` | String   | Human readable error description (can be localized) |
-| `error_details`     | String[] | Array of error details |
+  * [Vehicle State Events](#vehicle-state-events)
+* [Vehicle Types](#vehicle-types)
+* [Versioning](#versioning)
 
 ## Beta Features
 
@@ -83,21 +28,7 @@ Users of beta features are strongly encouraged to share their experiences, learn
 
 Working Groups and their Steering Committees are expected to review beta designated features with each release cycle and determine whether the feature has reached the level of stability and maturity needed to remove the beta designation. In a case where a beta feature fails to reach substantial adoption after an extended time, Working Group Steering Committees should discuss whether or not the feature should remain in the specification.
 
-[Top](#table-of-contents)
-
-## Timestamps
-
-A `timestamp` refers to integer milliseconds since Unix epoch.
-
-## Strings
-
-All String fields, such as `vehicle_id`, are limited to a maximum of 255 characters.
-
-## UUIDs
-
-Object identifiers are described via Universally Unique Identifiers [(UUIDs)](https://en.wikipedia.org/wiki/Universally_unique_identifier).  For example, the `device_id` field used to uniquely identify a vehicle is a UUID.
-
-MDS uses Version 1 UUIDs.
+[Top][toc]
 
 ## Costs and currencies
 
@@ -105,22 +36,15 @@ Fields specifying a monetary cost use a currency as specified in [ISO 4217](http
 
 If the currency field is null, USD cents is implied.
 
+[Top][toc]
+
 ## Devices
 
 MDS defines the *device* as the unit that transmits GPS or GNSS signals for a particular vehicle. A given device must have a UUID (`device_id` below) that is unique within the Provider's fleet.
 
 Additionally, `device_id` must remain constant for the device's lifetime of service, regardless of the vehicle components that house the device.
 
-## Vehicle Types
-
-The list of allowed `vehicle_type` values in MDS is:
-
-| `vehicle_type` | Description |
-|--------------| --- |
-| bicycle      | Anything with pedals, including recumbents; can include powered assist |
-| car          | Any automobile |
-| scooter      | Any motorized mobility device intended for one rider |
-| moped        | A motorcycle/bicycle hybrid that can be powered or pedaled |
+[Top][toc]
 
 ## Propulsion Types
 
@@ -132,6 +56,56 @@ The list of allowed `vehicle_type` values in MDS is:
 | `combustion`      | Contains throttle mode with a gas engine-powered motor |
 
 A vehicle may have one or more values from the `propulsion`, depending on the number of modes of operation. For example, a scooter that can be powered by foot or by electric motor would have the `propulsion` represented by the array `['human', 'electric']`. A bicycle with pedal-assist would have the `propulsion` represented by the array `['human', 'electric_assist']` if it can also be operated as a traditional bicycle.
+
+[Top][toc]
+
+## Responses
+
+* **200:** OK: operation successful.
+* **201:** Created: `POST` operations, new object created
+* **400:** Bad request.
+* **401:** Unauthorized: Invalid, expired, or insufficient scope of token.
+* **404:** Not Found: Object does not exist, returned on `GET` or `POST` operations if the object does not exist.
+* **409:** Conflict: `POST` operations when an object already exists and an update is not possible.
+* **500:** Internal server error: In this case, the answer may contain a `text/plain` body with an error message for troubleshooting.
+
+### Error Messages
+
+```json
+{
+    "error": "...",
+    "error_description": "...",
+    "error_details": [ "...", "..." ]
+}
+```
+
+| Field               | Type     | Field Description      |
+| ------------------- | -------- | ---------------------- |
+| `error`             | String   | Error message string   |
+| `error_description` | String   | Human readable error description (can be localized) |
+| `error_details`     | String[] | Array of error details |
+
+[Top][toc]
+
+## Strings
+
+All String fields, such as `vehicle_id`, are limited to a maximum of 255 characters.
+
+[Top][toc]
+
+## Timestamps
+
+A `timestamp` refers to integer milliseconds since Unix epoch.
+
+[Top][toc]
+
+## UUIDs
+
+Object identifiers are described via Universally Unique Identifiers [(UUIDs)](https://en.wikipedia.org/wiki/Universally_unique_identifier). For example, the `device_id` field used to uniquely identify a vehicle is a UUID.
+
+MDS uses Version 1 UUIDs.
+
+[Top][toc]
 
 ## Vehicle States
 
@@ -149,7 +123,9 @@ In a multi-jurisdiction environment, the status of a vehicle is per-jurisdiction
 | `elsewhere`       | no | Outside of regulator's jurisdiction, and thus not subject to cap-counts or other regulations. Example: a vehicle that started a trip in L.A. has transitioned to Santa Monica.  |
 | `unknown`         | unknown | Provider has lost contact with the vehicle and its disposition is unknown.  Examples include: taken into a private residence, thrown in river. |
 
-## Vehicle Events
+[Top][toc]
+
+### Vehicle State Events
 
 This is the list of `vehicle_state` and `event_type` pairings that constitute the valid transitions of the vehicle state machine.
 
@@ -190,3 +166,59 @@ NOTES:
 Should we try to handle "unlicensed movements"?
 
 What's the best way to return from `unknown`? 
+
+[Top][toc]
+
+## Vehicle Types
+
+The list of allowed `vehicle_type` values in MDS is:
+
+| `vehicle_type` | Description |
+|--------------| --- |
+| bicycle      | Anything with pedals, including recumbents; can include powered assist |
+| car          | Any automobile |
+| scooter      | Any motorized mobility device intended for one rider |
+| moped        | A motorcycle/bicycle hybrid that can be powered or pedaled |
+
+[Top][toc]
+
+## Versioning
+
+MDS APIs must handle requests for specific versions of the specification from clients.
+
+Versioning must be implemented through the use of a custom media-type, `application/vnd.mds+json`, combined with a required `version` parameter.
+
+The version parameter specifies the dot-separated combination of major and minor versions from a published version of the specification. For example, the media-type for version `1.0.1` would be specified as `application/vnd.mds+json;version=1.0`
+
+Clients must specify the version they are targeting through the `Accept` header. For example:
+
+```http
+Accept: application/vnd.mds+json;version=0.3
+```
+
+> Since versioning was not available from the start, the following APIs provide a fallback version if the `Accept` header is not set as specified above:
+> - The `provider` API must respond as if version `0.2` was requested.
+> - The `agency` API must respond as if version `0.3` was requested.
+> - The `policy` API must respond as if version `0.4` was requested.
+
+If an unsupported or invalid version is requested, the API must respond with a status of `406 Not Acceptable`. If this occurs, a client can explicitly negotiate available versions.
+
+A client negotiates available versions using the `OPTIONS` method to an MDS endpoint. For example, to check if `trips` supports either version `0.2` or `0.3` with a preference for `0.2`, the client would issue the following request:
+
+```http
+OPTIONS /trips/ HTTP/1.1
+Host: provider.example.com
+Accept: application/vnd.mds+json;version=0.2,application/vnd.mds+json;version=0.3;q=0.9
+```
+
+The response will include the most preferred supported version in the `Content-Type` header. For example, if only `0.3` is supported:
+
+```http
+Content-Type: application/vnd.mds+json;version=0.3
+```
+
+The client can use the returned value verbatim as a version request in the `Accept` header.
+
+[Top][toc]
+
+[toc]: #table-of-contents

--- a/policy/README.md
+++ b/policy/README.md
@@ -19,7 +19,7 @@ The following information applies to all `policy` API endpoints.
 
 `policy` APIs must handle requests for specific versions of the specification from clients.
 
-Versioning must be implemented as specified in the [`General information versioning section`][versioning].
+Versioning must be implemented as specified in the [Versioning section][versioning].
 
 ## Background
 
@@ -63,31 +63,11 @@ Among other use-cases, configuring a REST API allows an Agency to:
 
 Responses must set the `Content-Type` header, as specified in the [Provider versioning][versioning] section.
 
-#### HTTP Response Codes
+#### Responses and Error Messages
 
-The response to a client request must include a valid HTTP status code defined in the [IANA HTTP Status Code Registry][iana]
+The response to a client request must include a valid HTTP status code defined in the [IANA HTTP Status Code Registry][iana].
 
-- **200:** OK: operation successful.
-- **400:** Bad request.
-- **401:** Unauthorized: Invalid, expired, or insufficient scope of token.
-- **404:** Not Found: Object(s) do not exist.
-- **500:** Internal server error.
-
-#### Error Responses
-
-```json
-{
-    "error": "...",
-    "error_description": "...",
-    "error_details": [ "...", "..." ]
-}
-```
-
-| Field               | Type     | Field Description      |
-| ------------------- | -------- | ---------------------- |
-| `error`             | String   | Error message string   |
-| `error_description` | String   | Human readable error description (can be localized) |
-| `error_details`     | String[] (optional) | Array of error details |
+See the [Responses section][responses] for information on valid MDS response codes and the [Error Messages section][error-messages] for information on formatting error messages.
 
 #### Policies
 
@@ -281,13 +261,13 @@ The internal mechanics of ordering are up to the Policy editing and hosting soft
 
 [Top][toc]
 
-[toc]: #table-of-contents
+[beta]: /general-information.md#beta
 [iana]: https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 [muni-boundary]: ../provider/README.md#municipality-boundary
-[timestamps]: /general-information.md#timestamps
-[beta]: /general-information.md#beta
-[versioning]: /general-information.md#versioning
-[vehicle-types]: /general-information.md#vehicle-types
-[vehicle-states]: /general-information.md#vehicle-states
-[vehicle-events]: /general-information.md#vehicle-events
 [propulsion-types]: /general-information.md#propulsion-types
+[timestamps]: /general-information.md#timestamps
+[toc]: #table-of-contents
+[vehicle-events]: /general-information.md#vehicle-state-events
+[vehicle-states]: /general-information.md#vehicle-states
+[vehicle-types]: /general-information.md#vehicle-types
+[versioning]: /general-information.md#versioning

--- a/provider/README.md
+++ b/provider/README.md
@@ -5,18 +5,16 @@ This specification contains a data standard for *mobility as a service* provider
 ## Table of Contents
 
 * [General Information](#general-information)
-* [Trips](#trips)
-* [Status Changes](#status-changes)
+* [Trips][trips]
+* [Status Changes][status]
 * [Realtime Data](#realtime-data)
   * [GBFS](#GBFS)
-  * [Events](#events)
-  * [Vehicles](#vehicles)
+  * [Events][events]
+  * [Vehicles][vehicles]
 
 ## General Information
 
 The following information applies to all `provider` API endpoints. Details on providing authorization to endpoints is specified in the [auth](auth.md) document.
-
-Currently, the provider API is implemented for shared dockless scooters, bikes, cars and mopeds. To implement another mode, please submit a PR.
 
 This specification uses data types including timestamps, UUIDs, and vehicle state definitions as described in the MDS [General Information][general-information] document.
 
@@ -24,11 +22,17 @@ This specification uses data types including timestamps, UUIDs, and vehicle stat
 
 `provider` APIs must handle requests for specific versions of the specification from clients.
 
-Versioning must be implemented as specified in the [`General information versioning section`][versioning].
+Versioning must be implemented as specified in the [Versioning section][versioning].
+
+[Top][toc]
 
 ### Response Format
 
-The response to a client request must include a valid HTTP status code defined in the [IANA HTTP Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml). It also must set the `Content-Type` header, as specified in the [Versioning][versioning] section.
+The response to a client request must include a valid HTTP status code defined in the [IANA HTTP Status Code Registry][iana].
+
+See the [Responses section][responses] for information on valid MDS response codes and the [Error Messages section][error-messages] for information on formatting error messages.
+
+The response must set the `Content-Type` header as specified in the [Versioning section][versioning].
 
 Response bodies must be a `UTF-8` encoded JSON object and must minimally include the MDS `version` and a `data` payload:
 
@@ -44,44 +48,23 @@ Response bodies must be a `UTF-8` encoded JSON object and must minimally include
 }
 ```
 
-#### HTTP Response Codes
-
-* **200:** OK: operation successful.
-* **400:** Bad request.
-* **401:** Unauthorized: Invalid, expired, or insufficient scope of token.
-* **404:** Not Found: Object(s) do not exist.
-* **500:** Internal server error.
-
-#### Error Format
-
-```json
-{
-    "error": "...",
-    "error_description": "...",
-    "error_details": [ "...", "..." ]
-}
-```
-
-| Field               | Type     | Field Description      |
-| ------------------- | -------- | ---------------------- |
-| `error`             | String   | Error message string   |
-| `error_description` | String   | Human readable error description (can be localized) |
-| `error_details`     | String[] (optional) | Array of error details |
-
 All response fields must use `lower_case_with_underscores`.
 
-#### JSON Schema
+[Top][toc]
 
-MDS defines [JSON Schema](https://json-schema.org/) files for [`trips`][trips-schema], [`status_changes`][sc-schema], [`events`][events-schema], and [`vehicles`][vehicles-schema].
+### JSON Schema
+
+MDS defines [JSON Schema][json-schema] files for each endpoint.
 
 `provider` API responses must validate against their respective schema files. The schema files always take precedence over the language and examples in this and other supporting documentation meant for *human* consumption.
+
+[Top][toc]
 
 ### Pagination
 
 The `/trips` and `/status_changes` endpoints must not use pagination.
 
-If providers choose to use pagination for either of the `/events` or `/vehicles` endpoints, the pagination
-must comply with the [JSON API](http://jsonapi.org/format/#fetching-pagination) specification.
+If Providers choose to use pagination for either of the `/events` or `/vehicles` endpoints, the pagination must comply with the [JSON API][json-api-pagination] specification.
 
 The following keys must be used for pagination links:
 
@@ -110,12 +93,14 @@ At a minimum, paginated payloads must include a `next` key, which must be set to
 }
 ```
 
+[Top][toc]
+
 ### Geographic Data
 
-References to geographic datatypes (Point, MultiPolygon, etc.) imply coordinates encoded in the [WGS 84 (EPSG:4326)](https://en.wikipedia.org/wiki/World_Geodetic_System) standard GPS or GNSS projection expressed as [Decimal Degrees](https://en.wikipedia.org/wiki/Decimal_degrees).
+References to geographic datatypes (Point, MultiPolygon, etc.) imply coordinates encoded in the [WGS 84 (EPSG:4326)][wgs84] standard GPS or GNSS projection expressed as [Decimal Degrees][decimal-degrees].
 
 Whenever an individual location coordinate measurement is presented, it must be
-represented as a GeoJSON [`Feature`](https://tools.ietf.org/html/rfc7946#section-3.2) object with a corresponding [`timestamp`][ts] property and [`Point`](https://tools.ietf.org/html/rfc7946#section-3.1.2) geometry:
+represented as a GeoJSON [`Feature`][geojson-feature] object with a corresponding [`timestamp`][ts] property and [`Point`][geojson-point] geometry:
 
 ```json
 {
@@ -135,7 +120,7 @@ represented as a GeoJSON [`Feature`](https://tools.ietf.org/html/rfc7946#section
 
 #### Intersection Operation
 
-For the purposes of this specification, the intersection of two geographic datatypes is defined according to the [`ST_Intersects` PostGIS operation](https://postgis.net/docs/ST_Intersects.html)
+For the purposes of this specification, the intersection of two geographic datatypes is defined according to the [`ST_Intersects` PostGIS operation][st-intersects]
 
 > If a geometry or geography shares any portion of space then they intersect. For geography -- tolerance is 0.00001 meters (so any points that are close are considered to intersect).
 >
@@ -145,11 +130,19 @@ For the purposes of this specification, the intersection of two geographic datat
 
 ### Municipality Boundary
 
-Municipalities requiring MDS Provider API compliance should provide an unambiguous digital source for the municipality boundary. This boundary must be used when determining which data each `provider` API endpoint will include.  
+Municipalities requiring MDS Provider API compliance should provide an unambiguous digital source for the municipality boundary. This boundary must be used when determining which data each `provider` API endpoint will include.
 
-The boundary should be defined as a polygon or collection of polygons. The file defining the boundary should be provided in Shapefile or GeoJSON format and hosted online at a published address that all providers and `provider` API consumers can access and download. The boundary description can be sent as a reference to an object via the Geography API, or a reference to a Geography via the Jurisdiction API.  
+The boundary should be defined as a polygon or collection of polygons. The file defining the boundary should be provided in Shapefile or GeoJSON format and hosted online at a published address that all providers and `provider` API consumers can access and download. The boundary description can be sent as a reference to an object via the Geography API, or a reference to a Geography via the Jurisdiction API.
 
 Providers are not required to recalculate the set of historical data that is included when the municipality boundary changes. All new data must use the updated municipality boundary.
+
+[Top][toc]
+
+### Event Times
+
+Because of the unreliability of device clocks, the Provider is unlikely to know with total confidence what time an event occurred at. However, Providers are responsible for constructing as accurate a timeline as possible. Most importantly, the order of the timestamps for a particular device's events must reflect the Provider's best understanding of the order in which those events occurred.
+
+[Top][toc]
 
 ### Timestamps, Vehicle Types, Propulsion Types, UUIDs, Costs & Currencies
 
@@ -163,11 +156,11 @@ A trip represents a journey taken by a *mobility as a service* customer with a g
 
 The trips endpoint allows a user to query historical trip data.
 
-Unless stated otherwise by the municipality, the trips endpoint must return all trips with a `route` which [intersects](#intersection-operation) with the [municipality boundary](#municipality-boundary).
+Unless stated otherwise by the municipality, the trips endpoint must return all trips with a `route` which [intersects][intersection] with the [municipality boundary][muni-boundary].
 
 **Endpoint:** `/trips`  
 **Method:** `GET`  
-**[Beta feature](/general-information.md#beta-features):** No  
+**[Beta feature][beta]:** No  
 **Schema:** [`trips` schema][trips-schema]  
 **`data` Payload:** `{ "trips": [] }`, an array of objects with the following structure  
 
@@ -177,8 +170,8 @@ Unless stated otherwise by the municipality, the trips endpoint must return all 
 | `provider_name` | String | Required | The public-facing name of the Provider |
 | `device_id` | UUID | Required | A unique device ID in UUID format |
 | `vehicle_id` | String | Required | The Vehicle Identification Number visible on the vehicle itself |
-| `vehicle_type` | Enum | Required | See [vehicle types](../shared/README.md#vehicle-types) table |
-| `propulsion_type` | Enum[] | Required | Array of [propulsion types](../shared/README.md#propulsion-types); allows multiple values |
+| `vehicle_type` | Enum | Required | See [vehicle types][vehicle-types] table |
+| `propulsion_type` | Enum[] | Required | Array of [propulsion types][propulsion-types]; allows multiple values |
 | `trip_id` | UUID | Required | A unique ID for each trip |
 | `trip_duration` | Integer | Required | Time, in Seconds |
 | `trip_distance` | Integer | Required | Trip Distance, in Meters |
@@ -190,7 +183,7 @@ Unless stated otherwise by the municipality, the trips endpoint must return all 
 | `parking_verification_url` | String | Optional | A URL to a photo (or other evidence) of proper vehicle parking |
 | `standard_cost` | Integer | Optional | The cost, in the currency defined in `currency`, that it would cost to perform that trip in the standard operation of the System (see [Costs & Currencies][costs-and-currencies]) |
 | `actual_cost` | Integer | Optional | The actual cost, in the currency defined in `currency`, paid by the customer of the *mobility as a service* provider (see [Costs & Currencies][costs-and-currencies]) |
-| `currency` | String | Optional, USD cents is implied if null.| An [ISO 4217 Alphabetic Currency Code](https://en.wikipedia.org/wiki/ISO_4217#Active_codes) representing the currency of the payee (see [Costs & Currencies][costs-and-currencies]) |
+| `currency` | String | Optional, USD cents is implied if null.| An [ISO 4217 Alphabetic Currency Code][iso4217] representing the currency of the payee (see [Costs & Currencies][costs-and-currencies]) |
 
 ### Trips Query Parameters
 
@@ -204,13 +197,13 @@ If the data does not exist or the hour has not completed, `/trips` shall return 
 
 Without an `end_time` query parameter, `/trips` shall return a `400 Bad Request` error.
 
-For the near-ish real time use cases, please use the [events](#events) endpoint.
+For the near-ish real time use cases, please use the [events][events] endpoint.
 
 ### Routes
 
-To represent a route, MDS `provider` APIs must create a GeoJSON [`FeatureCollection`](https://tools.ietf.org/html/rfc7946#section-3.3), which includes every [observed point][geo] in the route, even those which occur outside the [municipality boundary](#municipality-boundary).
+To represent a route, MDS `provider` APIs must create a GeoJSON [`FeatureCollection`][geojson-feature-collection], which includes every [observed point][geo] in the route, even those which occur outside the [municipality boundary][muni-boundary].
 
-Routes must include at least 2 points: the start point and end point. Routes must include all possible GPS or GNSS samples collected by a Provider. Providers may round the latitude and longitude to the level of precision representing the maximum accuracy of the specific measurement. For example, [a-GPS](https://en.wikipedia.org/wiki/Assisted_GPS) is accurate to 5 decimal places, [differential GPS](https://en.wikipedia.org/wiki/Differential_GPS) is generally accurate to 6 decimal places. Providers may round those readings to the appropriate number for their systems.
+Routes must include at least 2 points: the start point and end point. Routes must include all possible GPS or GNSS samples collected by a Provider. Providers may round the latitude and longitude to the level of precision representing the maximum accuracy of the specific measurement. For example, [a-GPS][agps] is accurate to 5 decimal places, [differential GPS][dgps] is generally accurate to 6 decimal places. Providers may round those readings to the appropriate number for their systems.
 
 ```js
 "route": {
@@ -254,12 +247,12 @@ The status changes endpoint allows a user to query the historical availability f
 
 Unless stated otherwise by the municipality, this endpoint must return only those status changes with a `event_location` that [intersects](#intersection-operation) with the [municipality boundary](#municipality-boundary).
 
-> Note: As a result of this definition, consumers should query the [trips endpoint](#trips) to infer when vehicles enter or leave the municipality boundary.
+> Note: As a result of this definition, consumers should query the [trips endpoint][trips] to infer when vehicles enter or leave the municipality boundary.
 
 **Endpoint:** `/status_changes`  
 **Method:** `GET`  
-**[Beta feature](/general-information.md#beta-features):** No  
-**Schema:** [`status_changes` schema][sc-schema]  
+**[Beta feature][beta]:** No  
+**Schema:** [`status_changes` schema][status-schema]  
 **`data` Payload:** `{ "status_changes": [] }`, an array of objects with the following structure
 
 | Field | Type | Required/Optional | Comments |
@@ -268,20 +261,16 @@ Unless stated otherwise by the municipality, this endpoint must return only thos
 | `provider_name` | String | Required | The public-facing name of the Provider |
 | `device_id` | UUID | Required | A unique device ID in UUID format |
 | `vehicle_id` | String | Required | The Vehicle Identification Number visible on the vehicle itself |
-| `vehicle_type` | Enum | Required | see [vehicle types](../shared/README.md#vehicle-types) table |
-| `propulsion_type` | Enum[] | Required | Array of [propulsion types](../shared/README.md#propulsion-types); allows multiple values |
-| `vehicle_state` | Enum | Required | See [vehicle state](../shared/README.md#vehicle-state) table |
-| `event_type` | Enum[] | Required | Reason(s) for state change, allowable values determined by [`event-type`](../shared/README.md#event-types) |
-| `event_time` | [timestamp][ts] | Required | Date/time that event occurred at. See [timestamps](../shared/README.md#timestamps) |
+| `vehicle_type` | Enum | Required | see [vehicle types][vehicle-types] table |
+| `propulsion_type` | Enum[] | Required | Array of [propulsion types][propulsion-types]; allows multiple values |
+| `vehicle_state` | Enum | Required | See [vehicle state][vehicle-states] table |
+| `event_type` | Enum[] | Required | [Vehicle event(s)][vehicle-events] for state change, allowable values determined by `vehicle_state`. |
+| `event_time` | [timestamp][ts] | Required | Date/time that event occurred at. See [Event Times][event-times] |
 | `publication_time` | [timestamp][ts] | Optional | Date/time that event became available through the status changes endpoint |
 | `event_location` | GeoJSON [Point Feature][geo] | Required | |
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 | `associated_trip` | UUID | Required if Applicable | Trip UUID (foreign key to Trips API), required if `event_type` is `trip_start` or `trip_end`, or for any other status change event that marks the end of a trip. |
-| `associated_ticket` | String | Optional | Identifier for an associated ticket inside an Agency-maintained 311 or CRM system. | 
-
-### Event Times
-
-Because of the unreliability of device clocks, the Provider is unlikely to know with total confidence what time an event occurred at. However, they are responsible for constructing as accurate a timeline as possible. Most importantly, the order of the timestamps for a particular device's events must reflect the Provider's best understanding of the order in which those events occurred.
+| `associated_ticket` | String | Optional | Identifier for an associated ticket inside an Agency-maintained 311 or CRM system. |
 
 ### Status Changes Query Parameters
 
@@ -295,6 +284,8 @@ If the data does not exist or the hour has not completed, `/status_changes` shal
 
 Without an `event_time` query parameter, `/status_changes` shall return a `400 Bad Request` error.
 
+[Top][toc]
+
 ## Realtime Data
 
 ### GBFS
@@ -306,15 +297,17 @@ All MDS compatible `provider` APIs must expose a public [GBFS](https://github.co
 * `free_bike_status.json` is required for MDS
 * `station_information.json` and `station_status.json` don't apply for MDS
 
+[Top][toc]
+
 ### Events
 
 The `/events` endpoint is a near-ish real-time feed of status changes, designed to give access to as recent as possible series of events.
 
 The `/events` endpoint functions similarly to `/status_changes`, but shall not included data older than 2 weeks (that should live in `/status_changes.`)
 
-Unless stated otherwise by the municipality, this endpoint must return only those events with an `event_location` that [intersects](#intersection-operation) with the [municipality boundary](#municipality-boundary).
+Unless stated otherwise by the municipality, this endpoint must return only those events with an `event_location` that [intersects][intersection] with the [municipality boundary][muni-boundary].
 
-> Note: As a result of this definition, consumers should query the [trips endpoint](#trips) to infer when vehicles enter or leave the municipality boundary.
+> Note: As a result of this definition, consumers should query the [trips endpoint][trips] to infer when vehicles enter or leave the municipality boundary.
 
 The schema and datatypes are the same as those defined for [`/status_changes`][status].
 
@@ -323,10 +316,6 @@ The schema and datatypes are the same as those defined for [`/status_changes`][s
 **[Beta feature][beta]:** Yes (as of 0.4.0)  
 **Schema:** [`events` schema][events-schema]  
 **`data` Payload:** `{ "status_changes": [] }`, an array of objects with the same structure as in [`/status_changes`][status]
-
-#### Event Times
-
-Because of the unreliability of device clocks, the Provider is unlikely to know with total confidence what time an event occurred at. However, they are responsible for constructing as accurate a timeline as possible. Most importantly, the order of the timestamps for a particular device's events must reflect the Provider's best understanding of the order in which those events occurred.
 
 #### Events Query Parameters
 
@@ -341,9 +330,11 @@ Should either side of the requested time range be missing, `/events` shall retur
 
 Should either side of the requested time range be greater than 2 weeks before the time of the request, `/events` shall return a `400 Bad Request` error.
 
+[Top][toc]
+
 ### Vehicles
 
-The `/vehicles` endpoint returns the current status of vehicles on the PROW. Only vehicles that are currently in available, unavailable, or reserved states should be returned in this payload. Data in this endpoint should reconcile with data from the `/status_changes` enpdoint. The data returned by this endpoint should be as close to realtime as possible, but in no case should it be more than 5 minutes out-of-date. As with other MDS APIs, `/vehicles` is intended for use by regulators, not by the general public. It does not replace the role of a [GBFS](https://github.com/NABSA/gbfs) feed in enabling consumer-facing applications.
+The `/vehicles` endpoint returns the current status of vehicles on the PROW. Only vehicles that are currently in available, unavailable, or reserved states should be returned in this payload. Data in this endpoint should reconcile with data from the `/status_changes` enpdoint. The data returned by this endpoint should be as close to realtime as possible, but in no case should it be more than 5 minutes out-of-date. As with other MDS APIs, `/vehicles` is intended for use by regulators, not by the general public. It does not replace the role of a [GBFS][gbfs] feed in enabling consumer-facing applications.
 
 In addition to the standard [Provider payload wrapper](#response-format), responses from this endpoint should contain the last update timestamp and amount of time until the next update:
 
@@ -379,27 +370,48 @@ ttl                 | Yes       | Integer representing the number of millisecond
 | `vehicle_id` | String | Required | The Vehicle Identification Number visible on the vehicle itself, should match this device in provider |
 | `vehicle_type` | Enum | Required | see [vehicle types][vehicle-types] table |
 | `propulsion_type` | Enum[] | Required | Array of [propulsion types][propulsion-types]; allows multiple values |
-| `last_event_time` | [timestamp][timestamps] | Required | Date/time when last state change occurred. See [Event Times](#event-times) |
-| `last_vehicle_state` | Enum | Required | Event type of most recent state change. See [vehicle states][vehicle-states] table |
-| `last_vehicle_events` | Enum[] | Required | Event type reason(s) of most recent state change, allowable values determined by [`event type`](#event-types) |
+| `last_event_time` | [timestamp][ts] | Required | Date/time when last state change occurred. See [Event Times][event-times] |
+| `last_vehicle_state` | Enum | Required | Vehicle state of most recent state change. See [vehicle states][vehicle-states] table |
+| `last_vehicle_events` | Enum[] | Required | [Vehicle event(s)][vehicle-events] of most recent state change, allowable values determined by `last_vehicle_state`. |
 | `last_event_location` | GeoJSON [Point Feature][geo]| Required | Location of vehicle's last event |
 | `current_location` | GeoJSON [Point Feature][geo] | Required if Applicable | Current location of vehicle if different from last event, and the vehicle is not currently on a trip |
 | `battery_pct` | Float | Required if Applicable | Percent battery charge of device, expressed between 0 and 1 |
 
 [Top][toc]
 
-[toc]: #table-of-contents
-[geo]: #geographic-data
-[status]: #status-changes
-[timestamps]: /general-information.md#timestamps
+[agps]: https://en.wikipedia.org/wiki/Assisted_GPS
 [beta]: /general-information.md#beta
-[versioning]: /general-information.md#versioning
+[costs-and-currencies]: /general-information.md#costs-and-currencies
+[decimal-degrees]: https://en.wikipedia.org/wiki/Decimal_degrees
+[dgps]: https://en.wikipedia.org/wiki/Differential_GPS
+[events]: #events
+[events-schema]: dockless/events.json
+[event-times]: #event-times
+[gbfs]: https://github.com/NABSA/gbfs
+[general-information]: /general-information.md
+[geo]: #geographic-data
+[geojson-feature]: https://tools.ietf.org/html/rfc7946#section-3.2
+[geojson-feature-collection]: https://tools.ietf.org/html/rfc7946#section-3.3
+[geojson-point]: https://tools.ietf.org/html/rfc7946#section-3.1.2
+[iana]: https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+[intersection]: #intersection-operation
+[iso4217]: https://en.wikipedia.org/wiki/ISO_4217#Active_codes
+[json-api-pagination]: http://jsonapi.org/format/#fetching-pagination
+[json-schema]: https://json-schema.org
+[muni-boundary]: #municipality-boundary
+[propulsion-types]: /general-information.md#propulsion-types
+[responses]: /general-information.md#responses
+[status]: #status-changes
+[status-schema]: dockless/status_changes.json
+[st-intersects]: https://postgis.net/docs/ST_Intersects.html
+[toc]: #table-of-contents
+[trips]: #trips
+[trips-schema]: dockless/trips.json
+[ts]: /general-information.md#timestamps
+[vehicles]: #vehicles
 [vehicle-types]: /general-information.md#vehicle-types
 [vehicle-states]: /general-information.md#vehicle-states
-[vehicle-events]: /general-information.md#vehicle-events
-[propulsion-types]: /general-information.md#propulsion-types
-[costs-and-currencies]: /general-information.md#costs-and-currencies
-[events-schema]: dockless/events.json
-[sc-schema]: dockless/status_changes.json
-[trips-schema]: dockless/trips.json
+[vehicle-events]: /general-information.md#vehicle-state-events
 [vehicles-schema]: dockless/vehicles.json
+[versioning]: /general-information.md#versioning
+[wgs84]: https://en.wikipedia.org/wiki/World_Geodetic_System


### PR DESCRIPTION
This looks like a lot of changes, but really it amounts to some reorganization (alphabetizing the General Info doc sections) and using markdown reference links where possible (for both internal and external links). 