### PR TITLE
Explicit prior states for some transitions

### DIFF
--- a/general-information.md
+++ b/general-information.md
@@ -156,7 +156,7 @@ Note that to handle out-of-order events, the validity of the prior-state shall n
 | `available` | `non_operational` | `unspecified`        | The vehicle became unavailable, but he Provider cannot definitively (yet) specify the reason. |
 | `available`, `non_operational`, `elsewhere` | `removed`     | `rebalance_pick_up`  | The provider picked up the vehicle for rebalancing purposes |
 | `available`, `non_operational`, `elsewhere` | `removed`     | `maintenance_pick_up` | The provider picked up the vehicle to service it |
-| any | `removed`     | `agency_pick_up`     | An agency picked up the vehicle for some reason, e.g. illegal placement |
+| `available`, `non_operational`, `elsewhere`, `unknown` | `removed`     | `agency_pick_up`     | An agency picked up the vehicle for some reason, e.g. illegal placement |
 | `available`, `non_operational`, `elsewhere` | `removed`     | `compliance_pick_up` | The provider picked up the vehicle because it was placed in a non-compliant location |
 | `available`, `non_operational`, `removed`, `elsewhere`, `unknown` | `removed`     | `decommissioned`     | The provider has removed the vehicle from its fleet |
 | `unknown`, `non_operational`, `available`, `elsewhere` | `removed`     | `unspecified`        | The vehicle was removed, but the provider cannot definitively (yet) specify the reason |

--- a/general-information.md
+++ b/general-information.md
@@ -160,8 +160,8 @@ Note that to handle out-of-order events, the validity of the prior-state shall n
 | `available`, `non_operational`, `elsewhere` | `removed`     | `compliance_pick_up` | The provider picked up the vehicle because it was placed in a non-compliant location |
 | `available`, `non_operational`, `removed`, `elsewhere`, `unknown` | `removed`     | `decommissioned`     | The provider has removed the vehicle from its fleet |
 | `unknown`, `non_operational`, `available`, `elsewhere` | `removed`     | `unspecified`        | The vehicle was removed, but the provider cannot definitively (yet) specify the reason |
-| any | `unknown`     | `missing`            | The vehicle is not at its last reported GPS location, or that location is wildly in error |
-| any | `unknown`     | `out_of_comms`       | The vehicle is unable to transmit its GPS location |
+| `available`, `reserved`, `on_trip`, `non_operational`, `elsewhere` | `unknown`     | `missing`            | The vehicle is not at its last reported GPS location, or that location is wildly in error |
+| `available`, `reserved`, `on_trip`, `non_operational`, `elsewhere` | `unknown`     | `out_of_comms`       | The vehicle is unable to transmit its GPS location |
 
 NOTES:
 


### PR DESCRIPTION
A few transitions mentioned "any" as the valid prior-state, when it makes more sense to have an explicit list of a few states.

For example, the the transition to `unknown` via `out_of_comms` doesn't make sense if the vehicle is currently `removed`. 