### PR TITLE
Adding 'other' as a vehicle_type

### DIFF
--- a/agency/get_vehicle.json
+++ b/agency/get_vehicle.json
@@ -27,7 +27,8 @@
         "bicycle",
         "car",
         "scooter",
-        "moped"
+        "moped",
+        "other"
       ]
     },
     "vehicle_status": {

--- a/agency/post_vehicle.json
+++ b/agency/post_vehicle.json
@@ -27,7 +27,8 @@
         "bicycle",
         "car",
         "scooter",
-        "moped"
+        "moped",
+        "other"
       ]
     },
     "uuid": {

--- a/general-information.md
+++ b/general-information.md
@@ -181,6 +181,7 @@ The list of allowed `vehicle_type` values in MDS is:
 | car          | Any automobile |
 | scooter      | Any motorized mobility device intended for one rider |
 | moped        | A motorcycle/bicycle hybrid that can be powered or pedaled |
+| other        | Another vehicle type not covered by any of the other options |
 
 [Top][toc]
 

--- a/provider/dockless/status_changes.json
+++ b/provider/dockless/status_changes.json
@@ -173,7 +173,8 @@
         "bicycle",
         "car",
         "scooter",
-        "moped"
+        "moped",
+        "other"
       ]
     },
     "version": {

--- a/provider/dockless/trips.json
+++ b/provider/dockless/trips.json
@@ -204,7 +204,8 @@
         "bicycle",
         "car",
         "scooter",
-        "moped"
+        "moped",
+        "other"
       ]
     },
     "version": {

--- a/provider/dockless/vehicles.json
+++ b/provider/dockless/vehicles.json
@@ -173,7 +173,8 @@
         "bicycle",
         "car",
         "scooter",
-        "moped"
+        "moped",
+        "other"
       ]
     },
     "version": {

--- a/schema/templates/common.json
+++ b/schema/templates/common.json
@@ -60,7 +60,8 @@
         "bicycle",
         "car",
         "scooter",
-        "moped"
+        "moped",
+        "other"
       ]
     },
     "vehicle_event": {


### PR DESCRIPTION
This is to address https://github.com/openmobilityfoundation/mobility-data-specification/issues/518 as part of the Reconciliation work.